### PR TITLE
Kotlin 1.8.22 and Quarkus 3.2.0.CR1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    `java-test-fixtures`
 }
 
 repositories {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    `java-test-fixtures`
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
 
-    val kotlinVersion = "1.8.20"
+    val kotlinVersion = "1.8.22"
 
     kotlin("jvm") version kotlinVersion apply false
     kotlin("plugin.allopen") version kotlinVersion apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.1.1.Final
+quarkusPluginVersion=3.2.0.CR1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.1.1.Final
+quarkusPlatformVersion=3.2.0.CR1


### PR DESCRIPTION
This is just to illustrate the build being fine without `java-test-fixtures` plugin at Quarkus 3.1.1.Final 